### PR TITLE
patch: Dockerfile update to specify CUDA CC

### DIFF
--- a/ubuntu-20.04/opencv-4.5.3/cuda-11.4.1/Dockerfile
+++ b/ubuntu-20.04/opencv-4.5.3/cuda-11.4.1/Dockerfile
@@ -1,5 +1,6 @@
 FROM nvidia/cuda:11.4.1-devel-ubuntu20.04
 
+ARG DEBIAN_FRONTEND=noninteractive
 ARG OPENCV_VERSION=4.5.3
 
 RUN apt-get update && apt-get upgrade -y &&\
@@ -54,6 +55,7 @@ RUN cd /opt/ &&\
     cmake \
         -DOPENCV_EXTRA_MODULES_PATH=/opt/opencv_contrib-${OPENCV_VERSION}/modules \
         -DWITH_CUDA=ON \
+        -DCUDA_ARCH_BIN=7.5,8.0,8.6 \
         -DCMAKE_BUILD_TYPE=RELEASE \
         # Install path will be /usr/local/lib (lib is implicit)
         -DCMAKE_INSTALL_PREFIX=/usr/local \


### PR DESCRIPTION
Building usually fails when running without specifying CUDA compute capability - make fails to proceed when building with CC's <= 5.0 due to deprecation errors. Default behaviour is to include all CC's; to fix this the build now includes CC's for 7.5, onward (Turing and Ampere).